### PR TITLE
Add deploy.skip_cleanup with `true` value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: bundle exec rake docker:push
   on:
     tags: true


### PR DESCRIPTION
With `language: ruby`, Travis CI install gems into `vendor` directory. That's why [cleaning up when deploying](https://docs.travis-ci.com/user/deployment/#uploading-files-and-skip_cleanup) causes an error. 
