### PR TITLE
Publish images with `master` tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,14 @@ jobs:
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
       - name: Publish the Docker image
-        if: startsWith(github.ref, 'refs/tags/')
+        if: |
+          github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
-          export TAG="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
+          if [[ "$GITHUB_REF" = 'refs/heads/master' ]]; then
+            export TAG=master
+          else
+            export TAG="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
+          fi
           bundle exec rake docker:push
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}


### PR DESCRIPTION
I think this tag is useful when we want to run smoke tests of Runners with unpublished Docker images.