### PR TITLE
Fix `docker:push` rake task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
             export TAG=master
           else
             export TAG="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
+            export TAG_LATEST=true
           fi
           bundle exec rake docker:push
         env:

--- a/Rakefile
+++ b/Rakefile
@@ -59,9 +59,11 @@ namespace :docker do
   desc 'Run docker push'
   task :push do
     sh "docker login -u #{docker_user} -p #{docker_password}"
-    sh "docker tag #{image_name} #{image_name_latest}"
     sh "docker push #{image_name}"
-    sh "docker push #{image_name_latest}"
+    if tag_latest?
+      sh "docker tag #{image_name} #{image_name_latest}"
+      sh "docker push #{image_name_latest}"
+    end
   end
 end
 
@@ -80,6 +82,10 @@ end
 def tag
   key = 'TAG'
   ENV.fetch(key).tap { |value| abort "Environment variable `#{key}` must not be empty." if value.empty? }
+end
+
+def tag_latest?
+  ENV['TAG_LATEST'] == 'true'
 end
 
 def docker_user


### PR DESCRIPTION
This adds a new `TAG_LATEST` environment variable.
Only when the new variable is enabled, the `latest` tag of Docker images will be pushed.