### PR TITLE
Use official OpenJDK image

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM debian:buster-20190910
+FROM openjdk:13-jdk-buster
 
 ENV GLOBAL_RUBY_VERSION 2.6.4
 ENV BUNDLER1_VERSION 1.17.3
@@ -19,18 +19,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
-
-# Install Java
-ENV JAVA_VERSION 12.0.1
-ENV PATH /usr/local/java/bin:$PATH
-ARG TAR_URL=https://download.java.net/java/GA/jdk${JAVA_VERSION}/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz
-ARG SHA256_URL=https://download.java.net/java/GA/jdk${JAVA_VERSION}/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz.sha256
-RUN curl -fsSLO --compressed $TAR_URL && \
-    curl -fsSL -o sha256.txt --compressed $SHA256_URL && \
-    echo "$(cat sha256.txt) *openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" | sha256sum --check --strict && \
-    mkdir -p /usr/local/java && \
-    tar -xzf "openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" -C /usr/local/java --strip-components=1 && \
-    rm -rf "openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" sha256.txt
 
 # Install Maven
 ENV MAVEN_VERSION 3.6.2

--- a/java/Dockerfile.erb
+++ b/java/Dockerfile.erb
@@ -1,19 +1,7 @@
-FROM debian:buster-20190910
+FROM openjdk:13-jdk-buster
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>
-
-# Install Java
-ENV JAVA_VERSION 12.0.1
-ENV PATH /usr/local/java/bin:$PATH
-ARG TAR_URL=https://download.java.net/java/GA/jdk${JAVA_VERSION}/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz
-ARG SHA256_URL=https://download.java.net/java/GA/jdk${JAVA_VERSION}/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz.sha256
-RUN curl -fsSLO --compressed $TAR_URL && \
-    curl -fsSL -o sha256.txt --compressed $SHA256_URL && \
-    echo "$(cat sha256.txt) *openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" | sha256sum --check --strict && \
-    mkdir -p /usr/local/java && \
-    tar -xzf "openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" -C /usr/local/java --strip-components=1 && \
-    rm -rf "openjdk-${JAVA_VERSION}_linux-x64_bin.tar.gz" sha256.txt
 
 # Install Maven
 ENV MAVEN_VERSION 3.6.2


### PR DESCRIPTION
The version 12 has been dropped, so we should use the version 13 (latest).
Also, this official images provide only **major** versions.

Fix #47

## See also

- https://hub.docker.com/_/openjdk
- https://github.com/docker-library/openjdk/blob/60d76cf8c132ad10ea6c33c4f90b9e3d11deb0fe/13/jdk/Dockerfile#L1