### PR TITLE
Add `.bashrc`

### DIFF
--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -69,3 +69,13 @@ apt-get -qyy clean
 
 # Create a user
 adduser --system --shell /bin/bash --home "$RUNNER_USER_HOME" "$RUNNER_USER"
+
+# Configure Bash on shell
+cat<<'EOF' >> "${RUNNER_USER_HOME}/.bashrc"
+alias ls='ls --color=auto'
+alias ll='ls -lF'
+alias l='ls -lAF'
+alias grep='grep --color=auto'
+alias less='less -ciRM'
+EOF
+chown "${RUNNER_USER}:" "${RUNNER_USER_HOME}/.bashrc"


### PR DESCRIPTION
This adds useful aliases on login shell.
The `.bashrc` file is enable only on login shell and does not have no effect when running the normal command.