### PR TITLE
Downgrade Haskell from 8.8.1 to 8.6.5

### DIFF
--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -4,7 +4,11 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # NOTE: The base image is `debian:stretch` but we uses basically `debian:buster`.
 #       See https://github.com/freebroccolo/docker-haskell/issues/94
-FROM haskell:8.8.1
+#
+# NOTE: The version `8.6.5` is not latest and is including Cabal 2.4 (not latest too).
+#       Because ShellCheck does not work yet on the both latest versions.
+#       See https://github.com/koalaman/shellcheck/blob/de9ab4e6ef5262eeba6871a03ef3938a93b44395/ShellCheck.cabal#L40
+FROM haskell:8.6.5
 
 ENV GLOBAL_RUBY_VERSION 2.6.4
 ENV BUNDLER1_VERSION 1.17.3

--- a/haskell/Dockerfile.erb
+++ b/haskell/Dockerfile.erb
@@ -1,6 +1,10 @@
 # NOTE: The base image is `debian:stretch` but we uses basically `debian:buster`.
 #       See https://github.com/freebroccolo/docker-haskell/issues/94
-FROM haskell:8.8.1
+#
+# NOTE: The version `8.6.5` is not latest and is including Cabal 2.4 (not latest too).
+#       Because ShellCheck does not work yet on the both latest versions.
+#       See https://github.com/koalaman/shellcheck/blob/de9ab4e6ef5262eeba6871a03ef3938a93b44395/ShellCheck.cabal#L40
+FROM haskell:8.6.5
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>


### PR DESCRIPTION
The version `8.6.5` is not latest and is including Cabal 2.4 (not latest too).
Because ShellCheck does not work yet on the both latest versions.

See https://github.com/koalaman/shellcheck/blob/de9ab4e6ef5262eeba6871a03ef3938a93b44395/ShellCheck.cabal#L40