### PR TITLE
Fix Maven checksum

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -36,11 +36,11 @@ RUN curl -fsSLO --compressed $TAR_URL && \
 ENV MAVEN_VERSION 3.6.2
 ENV PATH /usr/local/maven/bin:$PATH
 ARG MAVEN_BINARY_URL=https://www.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-RUN curl -fsSL --compressed "${MAVEN_BINARY_URL}" -o maven-bin.tar.gz && \
-    curl -fsSL --compressed "${MAVEN_BINARY_URL}.sha512" | xargs -I {} echo "{} *maven-bin.tar.gz" | sha512sum --check --strict && \
+RUN curl -fsSLO --compressed "${MAVEN_BINARY_URL}" && \
+    curl -fsSL  --compressed "${MAVEN_BINARY_URL}.sha512" | sha512sum --check --strict && \
     mkdir -p /usr/local/maven && \
-    tar -xzf maven-bin.tar.gz -C /usr/local/maven --strip-components 1 && \
-    rm maven-bin.tar.gz
+    tar -xzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/local/maven --strip-components 1 && \
+    rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 
 # Following instructions should be run by $RUNNER_USER
 USER $RUNNER_USER

--- a/java/Dockerfile.erb
+++ b/java/Dockerfile.erb
@@ -19,11 +19,11 @@ RUN curl -fsSLO --compressed $TAR_URL && \
 ENV MAVEN_VERSION 3.6.2
 ENV PATH /usr/local/maven/bin:$PATH
 ARG MAVEN_BINARY_URL=https://www.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-RUN curl -fsSL --compressed "${MAVEN_BINARY_URL}" -o maven-bin.tar.gz && \
-    curl -fsSL --compressed "${MAVEN_BINARY_URL}.sha512" | xargs -I {} echo "{} *maven-bin.tar.gz" | sha512sum --check --strict && \
+RUN curl -fsSLO --compressed "${MAVEN_BINARY_URL}" && \
+    curl -fsSL  --compressed "${MAVEN_BINARY_URL}.sha512" | sha512sum --check --strict && \
     mkdir -p /usr/local/maven && \
-    tar -xzf maven-bin.tar.gz -C /usr/local/maven --strip-components 1 && \
-    rm maven-bin.tar.gz
+    tar -xzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/local/maven --strip-components 1 && \
+    rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 
 # Following instructions should be run by $RUNNER_USER
 USER $RUNNER_USER


### PR DESCRIPTION
The error is:

> sha512sum: 'apache-maven-3.6.2-bin.tar.gz *maven-bin.tar.gz': No such file or directory
> apache-maven-3.6.2-bin.tar.gz *maven-bin.tar.gz: FAILED open or read
> sha512sum: WARNING: 1 listed file could not be read