### PR TITLE
Extract `gemrc` file from shell script

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/base/Dockerfile.prepare.erb
+++ b/base/Dockerfile.prepare.erb
@@ -1,2 +1,4 @@
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
+
+COPY base/etc/* /usr/local/etc/

--- a/base/bin/build-ruby
+++ b/base/bin/build-ruby
@@ -18,12 +18,6 @@ ruby-build "$GLOBAL_RUBY_VERSION" "$PREFIX"
 [[ $(ruby -e 'puts RUBY_VERSION') = "$GLOBAL_RUBY_VERSION" ]] || (echo 'Unexpected Ruby version!' ; exit 1)
 ruby -v
 
-# Configure `gem` command
-cat<<'EOF' >> "${PREFIX}/etc/gemrc"
-install: --no-document
-update: --no-document
-EOF
-
 # Update `gem` command
 gem update --system
 gem environment

--- a/base/etc/gemrc
+++ b/base/etc/gemrc
@@ -1,0 +1,2 @@
+install: --no-document
+update: --no-document

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -24,6 +24,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY base/bin/* /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
+COPY base/etc/* /usr/local/etc/
+
 
 RUN /tmp/devon_rex_work/build-ruby
 


### PR DESCRIPTION
This change aims to increase maintainability by clarifying the `gemrc` file location.
(the embedded file content is hard to find.)