### PR TITLE
Use `gem info` instead of `gem list`

### DIFF
--- a/base/bin/build-ruby
+++ b/base/bin/build-ruby
@@ -27,6 +27,6 @@ gem environment
 #       See https://bunndler.io/blog/2019/01/03/announcing-bundler-2.html
 gem install bundler:"${BUNDLER1_VERSION}"
 gem install bundler:"${BUNDLER2_VERSION}"
-gem list bundler
+gem info bundler
 [[ $(bundle -v) = "Bundler version ${BUNDLER2_VERSION}" ]] || (echo 'Unexpected Bundler version!' ; exit 1)
 bundle -v


### PR DESCRIPTION
`gem info` outputs more information than `gem list`. This is useful for debugging.

For example:

```
bundler (2.1.4, 2.1.2, 1.17.3)
    Authors: André Arko, Samuel Giddins, Colby Swandale, Hiroshi
    Shibata, David Rodríguez, Grey Baker, Stephanie Morillo, Chris
    Morris, James Wen, Tim Moore, André Medeiros, Jessica Lynn Suttles,
    Terence Lee, Carl Lerche, Yehuda Katz
    Homepage: https://bundler.io
    License: MIT
    Installed at (2.1.4): /usr/local/lib/ruby/gems/2.7.0
                 (2.1.2, default): /usr/local/lib/ruby/gems/2.7.0
                 (1.17.3): /usr/local/lib/ruby/gems/2.7.0
```