### PR TITLE
Improve GitHub Actions configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,10 @@ jobs:
       - name: Define variables
         id: define_vars
         run: |
-          if [[ "${GITHUB_REF}" == 'refs/heads/master' ]]; then
-            tag="master"
-          else
-            tag="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
-          fi
-          echo "::set-output name=tag::${tag}"
+          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
+      - name: Print variables
+        run: |
+          echo "tag: ${{ steps.define_vars.outputs.tag }}"
       - name: Build and test the Docker image
         run: |
           bundle exec rake docker:build docker:run
@@ -53,14 +51,13 @@ jobs:
           TAG: ${{ steps.define_vars.outputs.tag }}
       - name: Publish the Docker image
         # if: |
-        #   github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        #   steps.define_vars.outputs.tag == 'master' || startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "TAG: $TAG"
           echo "TAG_LATEST: $TAG_LATEST"
           echo bundle exec rake docker:push
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}
-          TAG_LATEST: ${{ steps.define_vars.outputs.tag != 'master' }}
+          TAG_LATEST: ${{ startsWith(github.ref, 'refs/tags/') }}
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
           echo "tag: ${{ steps.define_vars.outputs.tag }}"
       - name: Build and test the Docker image
         run: |
+          bundle exec rake dockerfile:generate dockerfile:verify
           bundle exec rake docker:build docker:run
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,40 +25,42 @@ jobs:
           - ruby
           - swift
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: .ruby-version
       - name: Setup gems
         run: |
           gem install bundler --no-document
-          bundle install --jobs=4 --retry=3 --path=vendor/bundle
+          bundle config set --local path vendor/bundle
+          bundle install --jobs=4 --retry=3
+      - name: Show Docker information
+        run: docker info
+      - name: Define variables
+        id: define_vars
+        run: |
+          if [[ "${GITHUB_REF}" == 'refs/heads/master' ]]; then
+            tag="master"
+          else
+            tag="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
+          fi
+          echo "::set-output name=tag::${tag}"
       - name: Build and test the Docker image
         run: |
-          if [[ "$GITHUB_REF" = 'refs/heads/master' ]]; then
-            export TAG=master
-          else
-            export TAG="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
-          fi
-          docker info
-          bundle exec rake dockerfile:generate
-          bundle exec rake dockerfile:verify
-          bundle exec rake docker:build
-          bundle exec rake docker:run
+          bundle exec rake docker:build docker:run
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
+          TAG: ${{ steps.define_vars.outputs.tag }}
       - name: Publish the Docker image
-        if: |
-          github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        # if: |
+        #   github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
-          if [[ "$GITHUB_REF" = 'refs/heads/master' ]]; then
-            export TAG=master
-          else
-            export TAG="$(echo ${GITHUB_REF} | sed 's!refs/tags/!!' | sed 's!/!_!g')"
-            export TAG_LATEST=true
-          fi
-          bundle exec rake docker:push
+          echo "TAG: $TAG"
+          echo "TAG_LATEST: $TAG_LATEST"
+          echo bundle exec rake docker:push
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
+          TAG: ${{ steps.define_vars.outputs.tag }}
+          TAG_LATEST: ${{ steps.define_vars.outputs.tag != 'master' }}
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         run: docker info
       - name: Define variables
         id: define_vars
+        # See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
         run: |
           echo "GITHUB_REF: ${GITHUB_REF}"
           tag="${GITHUB_REF#refs/*/}"
@@ -53,11 +54,10 @@ jobs:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}
       - name: Publish the Docker image
-        # if: |
-        #   steps.define_vars.outputs.tag == 'master' || startsWith(github.ref, 'refs/tags/')
+        if: |
+          steps.define_vars.outputs.tag == 'master' || startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "TAG_LATEST: $TAG_LATEST"
-          echo bundle exec rake docker:push
+          bundle exec rake docker:push
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Define variables
         id: define_vars
         run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          tag="${GITHUB_REF#refs/*/}"
+          tag="${tag///}"
+          echo "::set-output name=tag::${tag}"
       - name: Print variables
         run: |
           echo "tag: ${{ steps.define_vars.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:


### PR DESCRIPTION
- Bump [actions/checkout](https://github.com/actions/checkout) from v1 to v2.
- Replace [actions/setup-ruby](https://github.com/actions/setup-ruby) with [ruby/setup-ruby](https://github.com/ruby/setup-ruby) to use the `.ruby-version` file.
- Replace `bundle install --path` option with `bundle config set` to avoid the Bundler deprecation.
- Reduce the duplication by using the [`::set-output`](https://help.github.com/en/actions/reference/development-tools-for-github-actions#set-an-output-parameter-set-output) parameter.