### PR TITLE
Reduce unneeded builds on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build and publish
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
 
 jobs:
   check_skip:
@@ -8,6 +12,7 @@ jobs:
     if: "! contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - run: echo "${{ github.event.head_commit.message }}"
+
   build:
     runs-on: ubuntu-latest
     needs: [check_skip]


### PR DESCRIPTION
`push` builds are unneeded on PRs.