### PR TITLE
Fix `skip ci` for `push` event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: Build
 
 on:
   push:
-    branches: ["master"]
+    #branches: ["master"]
+    branches: ["**"] # for test, it should be removed.
     tags: ["**"]
   pull_request:
     branches: ["**"]
@@ -20,6 +21,7 @@ jobs:
     steps:
       - run: |
           echo "github.event_name: '${{ github.event_name }}'"
+          echo "github.event: '${{ toJson(github.event) }}'"
           echo "github.event.push.commit.message: '${{ github.event.push.commit.message }}'"
           echo "github.event.pull_request.title: '${{ github.event.pull_request.title }}'"
           echo "github.event.pull_request.body: '${{ github.event.pull_request.body }}'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: Build
 
 on:
   push:
-    #branches: ["master"]
-    branches: ["**"] # for test, it should be removed.
+    branches: ["master"]
     tags: ["**"]
   pull_request:
     branches: ["**"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,12 @@ jobs:
     # - https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
     # - https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
     if: |
-      !(github.event_name == 'push' && contains(github.event.push.commit.message, '[skip ci]')) &&
+      !(github.event_name == 'push' && contains(github.event.head_commit.message, '[skip ci]')) &&
       !(github.event_name == 'pull_request' && contains(join(github.event.pull_request.title, github.event.pull_request.body), '[skip ci]'))
     steps:
       - run: |
           echo "github.event_name: '${{ github.event_name }}'"
-          echo "github.event: '${{ toJson(github.event) }}'"
-          echo "github.event.push.commit.message: '${{ github.event.push.commit.message }}'"
+          echo "github.event.head_commit.message: '${{ github.event.head_commit.message }}'"
           echo "github.event.pull_request.title: '${{ github.event.pull_request.title }}'"
           echo "github.event.pull_request.body: '${{ github.event.pull_request.body }}'"
 


### PR DESCRIPTION
`${{ github.event.push.commit.message }}` is empty. I will debug it.