### PR TITLE
Do not run releasing on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,15 @@
 name: Release
 
-on: push
+on:
+  push:
+    tags: ["**"]
 
 jobs:
-  release:
+  run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body: |
             See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/CHANGELOG.md) for more details.


### PR DESCRIPTION
This action is meaningless on pull requests.

See also <https://github.com/softprops/action-gh-release#-usage>