### PR TITLE
Fix `~/bin` directory permission

### DIFF
--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -78,4 +78,4 @@ EOF
 chown "${RUNNER_USER}:${RUNNER_GROUP}" "${RUNNER_USER_HOME}/.bashrc"
 
 # Create extra directories
-mkdir "${RUNNER_USER_HOME}/bin"
+install --directory --owner="${RUNNER_USER}" --group="${RUNNER_GROUP}" "${RUNNER_USER_HOME}/bin"


### PR DESCRIPTION
See [`install(1)`](https://linux.die.net/man/1/install).
See PR #196