### PR TITLE
Bump haskell from 8.8.3 to 8.10.1

### DIFF
--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -2,9 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# NOTE: The base image is `debian:stretch` but we uses basically `debian:buster`.
-#       See https://github.com/haskell/docker-haskell/issues/8
-FROM haskell:8.8.3
+FROM haskell:8.10.1-buster
 
 ENV GLOBAL_RUBY_VERSION 2.7.1
 ENV BUNDLER1_VERSION 1.17.3

--- a/haskell/Dockerfile.erb
+++ b/haskell/Dockerfile.erb
@@ -1,6 +1,4 @@
-# NOTE: The base image is `debian:stretch` but we uses basically `debian:buster`.
-#       See https://github.com/haskell/docker-haskell/issues/8
-FROM haskell:8.8.3
+FROM haskell:8.10.1-buster
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>


### PR DESCRIPTION
Also, the base Debian version has been updated from "stretch" to "buster."

Thanks to [this](https://github.com/sider/devon_rex/pull/205#discussion_r422733695) comment, I could update the base image with Debian buster.