### PR TITLE
Let $RUNNER_USER run update-ca-certificates(8) and apt-get(8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           bundle exec rake dockerfile:generate dockerfile:verify
           bundle exec rake docker:build docker:run
-          bundle exec rake docker:run'[update-ca-certificates]'
+          bundle exec rake docker:run'[sudo update-ca-certificates]'
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           bundle exec rake dockerfile:generate dockerfile:verify
           bundle exec rake docker:build docker:run
+          bundle exec rake docker:run'[update-ca-certificates]'
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           bundle exec rake dockerfile:generate dockerfile:verify
           bundle exec rake docker:build docker:run
           bundle exec rake docker:run'[sudo update-ca-certificates]'
+          bundle exec rake docker:run'[sudo apt-get clean]'
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.25.0...HEAD)
 
+- Let $RUNNER_USER run update-ca-certificates(8) and apt-get(8) [#272](https://github.com/sider/devon_rex/pull/272)
+
 ## 2.25.0
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.24.0...2.25.0)

--- a/Rakefile
+++ b/Rakefile
@@ -63,8 +63,9 @@ namespace :docker do
   end
 
   desc 'Run docker run without command. This task expects each image to show versions'
-  task :run do
-    sh 'docker', 'run', '--rm', image_name
+  task :run, [:cmd] do |_task, args|
+    cmd = (args[:cmd] || '').split(/\s+/)
+    sh 'docker', 'run', '--rm', image_name, *cmd
   end
 
   desc 'Run docker push'

--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -48,6 +48,9 @@ id --user "$RUNNER_USER"
 groups=$(id --groups --name "$RUNNER_USER")
 [[ "$groups" == "$RUNNER_GROUP" ]] || (echo "Unexpected groups: '${groups}'" ; exit 1)
 
+# Add sudoers(5) for update-ca-certificates(8)
+echo "$RUNNER_USER ALL=NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates
+
 # Configure Bash on shell
 cat << 'EOF' >> "${RUNNER_USER_HOME}/.bashrc"
 alias ls='ls --color=auto'

--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -32,7 +32,6 @@ required_packages=(
 apt-get update -y
 apt-get install -qq -y --no-install-recommends ${required_packages[*]}
 apt-get -qyy autoremove
-rm -rf /var/lib/apt/lists/*
 apt-get -qyy clean
 
 # Configure locale
@@ -48,8 +47,9 @@ id --user "$RUNNER_USER"
 groups=$(id --groups --name "$RUNNER_USER")
 [[ "$groups" == "$RUNNER_GROUP" ]] || (echo "Unexpected groups: '${groups}'" ; exit 1)
 
-# Add sudoers(5) for update-ca-certificates(8)
+# Add sudoers(5) configurations for specific commands
 echo "$RUNNER_USER ALL=NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates
+echo "$RUNNER_USER ALL=NOPASSWD: /usr/bin/apt-get" > /etc/sudoers.d/apt-get
 
 # Configure Bash on shell
 cat << 'EOF' >> "${RUNNER_USER_HOME}/.bashrc"


### PR DESCRIPTION
We're planning to support Git servers running with a self-signed certificate and will introduce the way to trust such a certificate by
executing update-ca-certificates(8) at runtime.

In order to let `$RUNNER_USER` run this command, I want to add sudoers(5) for the command.

In addition to allowing update-ca-certificates(8), apt-get(8) should be also allowed to execute. So, I added the permission for the command, too.

https://github.com/sider/runners/blob/dfd98c700a7f6ede165353bcd45facbab85448be/images/clang_tidy/Dockerfile.erb#L12