### PR TITLE
Allow $RUNNER_USER to add certificate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/devon_rex/compare/2.25.0...HEAD)
 
 - Let $RUNNER_USER run update-ca-certificates(8) and apt-get(8) [#272](https://github.com/sider/devon_rex/pull/272)
-- Allow $RUNNER_USER to add certificate files [#TODO](https://github.com/sider/devon_rex/pull/TODO)
+- Allow $RUNNER_USER to add certificate files [#284](https://github.com/sider/devon_rex/pull/284)
 
 ## 2.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/devon_rex/compare/2.25.0...HEAD)
 
 - Let $RUNNER_USER run update-ca-certificates(8) and apt-get(8) [#272](https://github.com/sider/devon_rex/pull/272)
+- Allow $RUNNER_USER to add certificate files [#TODO](https://github.com/sider/devon_rex/pull/TODO)
 
 ## 2.25.0
 

--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -51,6 +51,9 @@ groups=$(id --groups --name "$RUNNER_USER")
 echo "$RUNNER_USER ALL=NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates
 echo "$RUNNER_USER ALL=NOPASSWD: /usr/bin/apt-get" > /etc/sudoers.d/apt-get
 
+# Change owner to let $RUNNER_USER add certificate files
+chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Configure Bash on shell
 cat << 'EOF' >> "${RUNNER_USER_HOME}/.bashrc"
 alias ls='ls --color=auto'


### PR DESCRIPTION
Before executing update-ca-certificates(8), certificate files should be
stored in `/usr/local/share/ca-certificates`. This change allow
`$RUNNER_USER` to add certificate files within the directory.