### PR TITLE
Fix the feature to change the owner of /usr/local/share/ca-certificates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           bundle exec rake docker:build docker:run
           bundle exec rake docker:run'[sudo update-ca-certificates]'
           bundle exec rake docker:run'[sudo apt-get clean]'
+          bundle exec rake docker:run'[echo file > /usr/local/share/ca-certificates/file.crt]'
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.26.0...HEAD)
 
+- Fix the feature to change the owner of /usr/local/share/ca-certificates [#288](https://github.com/sider/devon_rex/pull/288)
+
 ## 2.26.0
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.25.0...2.26.0)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/base/Dockerfile.prepare.erb
+++ b/base/Dockerfile.prepare.erb
@@ -8,6 +8,10 @@ RUN test "$(git --version)" = "git version <%= ENV.fetch('GIT_VERSION') %>"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -51,9 +51,6 @@ groups=$(id --groups --name "$RUNNER_USER")
 echo "$RUNNER_USER ALL=NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/update-ca-certificates
 echo "$RUNNER_USER ALL=NOPASSWD: /usr/bin/apt-get" > /etc/sudoers.d/apt-get
 
-# Change owner to let $RUNNER_USER add certificate files
-chown "$RUNNER_USER" /usr/local/share/ca-certificates
-
 # Configure Bash on shell
 cat << 'EOF' >> "${RUNNER_USER_HOME}/.bashrc"
 alias ls='ls --color=auto'

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -58,6 +58,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -59,6 +59,10 @@ RUN test "$(git --version)" = "git version 2.28.0"
 # Install Ruby
 COPY --from=ruby:2.7.1 /usr/local /usr/local/
 
+# Change owner to let $RUNNER_USER add certificate files
+# WARNING: This must be done after copying ruby:2.7.1
+RUN chown "$RUNNER_USER" /usr/local/share/ca-certificates
+
 # Change USER and prepare Bundler
 USER $RUNNER_USER
 RUN gem update --system && \


### PR DESCRIPTION
Fix #287

The owner of `/usr/local/share/ca-certificates` should be changed after copying `ruby:2.7.1`.