### PR TITLE
Enable `bundler-cache` for ruby/setup-ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - name: Setup gems
-        run: bundle install
+        with:
+          bundler-cache: true
       - name: Show Docker information
         run: docker info
       - name: Define variables


### PR DESCRIPTION
> This action provides a way to automatically run `bundle install` and cache the result:

https://github.com/ruby/setup-ruby#caching-bundle-install-automatically