### PR TITLE
Use the same version of Bundler also in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,2 +1,9 @@
+rules:
+  - id: sider.devon_rex.bundler_version
+    pattern: BUNDLER2_VERSION
+    glob: .env
+    message: |
+      Use the same version of Bundler also in `Gemfile.lock`.
+
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml


### PR DESCRIPTION
I forgot to update `Gemfile.lock` in PR #352.
To avoid this, this change adds a Goodcheck rule.