### PR TITLE
Suppress bumping to PHP 8.0 via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,7 +71,7 @@ updates:
     ignore:
       - dependency-name: node
         versions:
-          # NOTE: Node 12 is the current LTS version. See https://github.com/nodejs/Release#readme
+          # NOTE: Node 12 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
           - ">= 13.a, < 16"
   - package-ecosystem: docker
     directory: "/php"
@@ -79,6 +79,11 @@ updates:
       interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
+    ignore:
+      - dependency-name: php
+        versions:
+          # NOTE: PHP 8.0 is a big release. See <https://www.php.net/releases/8.0/en.php>.
+          - ">= 7.a, < 8"
   - package-ecosystem: docker
     directory: "/python"
     schedule:


### PR DESCRIPTION
For example, see #370.

See also <https://www.php.net/releases/8.0/en.php>.