### PR TITLE
Bump bundler from 2.2.5 to 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Manage Bundler version in Gemfile [#372](https://github.com/sider/devon_rex/pull/372)
 - Bump node from 12.20.0-buster to 12.20.1-buster [#369](https://github.com/sider/devon_rex/pull/369)
 - Bump debian from buster-20201209 to buster-20210111 [#376](https://github.com/sider/devon_rex/pull/376)
+- Bump bundler from 2.2.5 to 2.2.6 [#388](https://github.com/sider/devon_rex/pull/388)
 
 ## 2.30.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.6.1'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '= 2.2.5'
+gem 'bundler', '= 2.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.5)
+  bundler (= 2.2.6)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.5
+   2.2.6


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.6
- https://github.com/rubygems/rubygems/compare/bundler-v2.2.5...bundler-v2.2.6