### PR TITLE
Fix ignoring versions for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,9 +70,8 @@ updates:
       timezone: Asia/Tokyo
     ignore:
       - dependency-name: node
-        versions:
-          # NOTE: Node 12 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
-          - ">= 13.a, < 16"
+        # NOTE: Node 12 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
+        versions: ["> 12"]
   - package-ecosystem: docker
     directory: "/php"
     schedule:
@@ -81,9 +80,8 @@ updates:
       timezone: Asia/Tokyo
     ignore:
       - dependency-name: php
-        versions:
-          # NOTE: PHP 8.0 is a big release. See <https://www.php.net/releases/8.0/en.php>.
-          - ">= 7.a, < 8"
+        # NOTE: PHP 8.0 is a big release. See <https://www.php.net/releases/8.0/en.php>.
+        versions: ["> 8"]
   - package-ecosystem: docker
     directory: "/python"
     schedule:


### PR DESCRIPTION
See the Dependabot source code:
https://github.com/dependabot/dependabot-core/blob/main/docker/spec/dependabot/docker/update_checker_spec.rb#L173-L176