### PR TITLE
Bump bundler from 2.2.6 to 2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Manage Bundler version in Gemfile [#372](https://github.com/sider/devon_rex/pull/372)
 - Bump node from 12.20.0-buster to 12.20.1-buster [#369](https://github.com/sider/devon_rex/pull/369)
 - Bump debian from buster-20201209 to buster-20210111 [#376](https://github.com/sider/devon_rex/pull/376)
-- Bump bundler from 2.2.5 to 2.2.6 [#388](https://github.com/sider/devon_rex/pull/388)
+- Bump bundler from 2.2.5 to 2.2.7 [#388](https://github.com/sider/devon_rex/pull/388) [#398](https://github.com/sider/devon_rex/pull/398)
 - Bump gradle from 6.7.1 to 6.8.1 [#389](https://github.com/sider/devon_rex/pull/389) [#396](https://github.com/sider/devon_rex/pull/396)
 - Bump git from 2.29.2 to 2.30.0 [#390](https://github.com/sider/devon_rex/pull/390)
 - Bump php from 7.4.12-buster to 7.4.14-buster [#394](https://github.com/sider/devon_rex/pull/394)

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.6.1'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '= 2.2.6'
+gem 'bundler', '= 2.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.6)
+  bundler (= 2.2.7)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.6
+   2.2.7


### PR DESCRIPTION
Via editing `Gemfile` and running `bundle update --system`.

- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.7
- https://github.com/rubygems/rubygems/compare/bundler-v2.2.6...bundler-v2.2.7