### PR TITLE
[Goodcheck] Remove needless `sider.devon_rex.bundler_version` rule

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,9 +1,2 @@
-rules:
-  - id: sider.devon_rex.bundler_version
-    pattern: BUNDLER2_VERSION
-    glob: .env
-    message: |
-      Use the same version of Bundler also in `Gemfile.lock`.
-
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml


### PR DESCRIPTION
The environment variable `BUNDLER2_VERSION` was removed via PR #372.