### PR TITLE
Add `versioning-strategy: increase` for Gemfile updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Main
   - package-ecosystem: bundler
     directory: "/"
+    versioning-strategy: increase
     schedule:
       interval: weekly
       time: "09:00"


### PR DESCRIPTION
This change aims to update the Bundler version as follows:
https://github.com/sider/devon_rex/blob/74b7f29c079f08a48de61d196327cd818450b7e2/Gemfile#L11

See also:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy