### PR TITLE
Bump bundler from 2.2.8 to 2.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.40.2...HEAD)
 
+- Bump bundler from 2.2.8 to 2.2.9 [#410](https://github.com/sider/devon_rex/pull/410)
+
 ## 2.40.2
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.40.1...2.40.2)

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.6.2'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '2.2.8'
+gem 'bundler', '2.2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.8)
+  bundler (= 2.2.9)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.8
+   2.2.9


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.9
- https://github.com/rubygems/rubygems/compare/bundler-v2.2.8...bundler-v2.2.9

*Note: Depedabot does not work yet.*