### PR TITLE
Remove custom skip-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,21 +8,7 @@ on:
     branches: ["**"]
 
 jobs:
-  # https://gist.github.com/ybiquitous/c80f15c18319c63cae8447a3be341267
-  check_skip:
-    runs-on: ubuntu-latest
-    if: |
-      !contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]')
-    steps:
-      - run: |
-          cat <<'MESSAGE'
-          github.event_name: ${{ toJson(github.event_name) }}
-          github.event:
-          ${{ toJson(github.event) }}
-          MESSAGE
-
   build:
-    needs: check_skip
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
*skip-ci* magic comments have been officially supported.
See <https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci>