### PR TITLE
Bump node from 12.20.1-buster to 14.16.0-buster

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,8 +70,8 @@ updates:
       timezone: Asia/Tokyo
     ignore:
       - dependency-name: node
-        # NOTE: Node 12 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
-        versions: ["> 12"]
+        # NOTE: Node 14 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
+        versions: ["> 14"]
   - package-ecosystem: docker
     directory: "/php"
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Bump gradle from 6.8.1 to 6.8.3 [#432](https://github.com/sider/devon_rex/pull/432)
 - Bump composer from 1.10.19 to 1.10.20 [#433](https://github.com/sider/devon_rex/pull/433)
 - Bump git from 2.30.0 to 2.30.1 [#434](https://github.com/sider/devon_rex/pull/434)
+- Bump node from 12.20.1-buster to 14.16.0-buster [#435](https://github.com/sider/devon_rex/pull/435)
 
 ## 2.40.6
 

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -7,6 +7,8 @@ rules:
     glob: "**/Dockerfile"
     message: |
       Update CHANGELOG.md when you change a based Docker image.
+    justification:
+      - When CHANGELOG.md is updated already.
 
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /tmp/git-build && \
     make install DESTDIR=/opt/git
 
 
-FROM node:12.20.1-buster
+FROM node:14.16.0-buster
 
 ENV GLOBAL_RUBY_VERSION 2.7.2
 ENV LANG en_US.UTF-8

--- a/npm/Dockerfile.erb
+++ b/npm/Dockerfile.erb
@@ -1,6 +1,6 @@
 <%= ERB.new(File.read('base/Dockerfile.git.erb')).result %>
 
-FROM node:12.20.1-buster
+FROM node:14.16.0-buster
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>


### PR DESCRIPTION
- https://github.com/nodejs/node/blob/v14.16.0/doc/changelogs/CHANGELOG_V14.md
- https://github.com/nodejs/node/releases/tag/v14.16.0

Close #320