### PR TITLE
Fix Dependabot PHP configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,8 +80,8 @@ updates:
       timezone: Asia/Tokyo
     ignore:
       - dependency-name: php
-        # NOTE: PHP 8.0 is a big release. See <https://www.php.net/releases/8.0/en.php>.
-        versions: ["> 8"]
+        # TODO: We now supports PHP 7 because PHP 8 is a big release (#387). See also <https://www.php.net/releases/8.0/en.php>.
+        versions: ["> 7"]
   - package-ecosystem: docker
     directory: "/python"
     schedule:


### PR DESCRIPTION
We want PHP 7 updates but have not received them recently.

The current version that we use is 7.4.14:

https://github.com/sider/devon_rex/blob/9ccfdea3a5300c94efc2265567c4019f3d74d0c6/php/Dockerfile#L36

But the latest version of PHP 7.x is **7.4.16**. See below:

- https://hub.docker.com/layers/php/library/php/7.4.16-buster/images/sha256-591baf692706373f9bae06043179f7e6f8f26d66fe10948285e1031622a5e46a?context=explore
- https://www.php.net/ChangeLog-7.php