### PR TITLE
Bump php from 7.4.14-buster to 7.4.16-buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/devon_rex/compare/2.42.2...HEAD)
 
 - Bump npm from 7.7.4 to 7.7.5 [#459](https://github.com/sider/devon_rex/pull/459)
+- Bump php from 7.4.14-buster to 7.4.16-buster [#461](https://github.com/sider/devon_rex/pull/461)
 
 ## 2.42.2
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /tmp/git-build && \
     make install DESTDIR=/opt/git
 
 
-FROM php:7.4.14-buster
+FROM php:7.4.16-buster
 
 ENV GLOBAL_RUBY_VERSION 2.7.2
 ENV LANG en_US.UTF-8

--- a/php/Dockerfile.erb
+++ b/php/Dockerfile.erb
@@ -1,6 +1,6 @@
 <%= ERB.new(File.read('base/Dockerfile.git.erb')).result %>
 
-FROM php:7.4.14-buster
+FROM php:7.4.16-buster
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>


### PR DESCRIPTION
See <https://www.php.net/ChangeLog-7.php>.

Note: Dependabot cannot bump it for some reason. (see also #460)