### PR TITLE
Set `versioning-strategy` for Dependabot Bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: daily
       time: "09:00"
       timezone: Asia/Tokyo
+    versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
We need to **always** update Bundler.

https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#versioning-strategy

https://github.com/sider/devon_rex/blob/338a45a4078db5e770b7c91ace62fe46c77653fc/Gemfile#L11