### PR TITLE
Bump bundler from 2.2.15 to 2.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.42.8...HEAD)
 
-- Bump bundler from 2.2.15 to 2.2.16 #503
+- Bump bundler from 2.2.15 to 2.2.16 [#503](https://github.com/sider/devon_rex/pull/503)
 
 ## 2.42.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.42.8...HEAD)
 
+- Bump bundler from 2.2.15 to 2.2.16 #503
+
 ## 2.42.8
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.42.7...2.42.8)

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.7.1'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '2.2.15'
+gem 'bundler', '2.2.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.15)
+  bundler (= 2.2.16)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.15
+   2.2.16


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.16
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.16/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.15/2.2.16