### PR TITLE
Clarify `docker login`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,9 @@ jobs:
         if: |
           steps.define_vars.outputs.tag == 'master' || startsWith(github.ref, 'refs/tags/')
         run: |
+          echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username '${{ secrets.DOCKER_USER }}' --password-stdin
           bundle exec rake docker:push
         env:
           BUILD_CONTEXT: ${{ matrix.build-context }}
           TAG: ${{ steps.define_vars.outputs.tag }}
           TAG_LATEST: ${{ startsWith(github.ref, 'refs/tags/') }}
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,6 @@ namespace :docker do
 
   desc 'Run docker push'
   task :push do
-    sh 'docker', 'login', '-u', docker_user, '-p', docker_password
     sh 'docker', 'push', image_name
     if tag_latest?
       sh 'docker', 'tag', image_name, image_name_latest
@@ -103,12 +102,4 @@ end
 
 def tag_latest?
   ENV['TAG_LATEST'] == 'true'
-end
-
-def docker_user
-  ENV.fetch('DOCKER_USER')
-end
-
-def docker_password
-  ENV.fetch('DOCKER_PASSWORD')
 end


### PR DESCRIPTION
This change extracts `docker login` from `rake docker:push` for clarity.

See also:
https://docs.docker.com/engine/reference/commandline/login/