### PR TITLE
Enable Content trust for Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Bump dotnet/sdk from 3.1.407-buster to 3.1.408-buster [#504](https://github.com/sider/devon_rex/pull/504)
 - Install `file` command [#506](https://github.com/sider/devon_rex/pull/506)
 - Add `RUNNER_USER_BIN` environment variable [#508](https://github.com/sider/devon_rex/pull/508)
+- Enable Content trust for Docker [#512](https://github.com/sider/devon_rex/pull/512)
 
 ## 2.42.8
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'dotenv/load'
 
 ENV['GLOBAL_RUBY_VERSION'] = Pathname('.ruby-version').read.chomp!
 ENV['DOCKER_BUILDKIT'] = '1'
+ENV['DOCKER_CONTENT_TRUST'] = '1'
 
 BUILD_CONTEXTS = %w[
   base


### PR DESCRIPTION
See also:
- https://docs.docker.com/engine/security/trust/
- https://github.com/goodwithtech/dockle/blob/94101bdcf6b7654db7dd934cf1544a1bb3c96a2b/CHECKPOINT.md#cis-di-0005

Related to #511