### PR TITLE
Bump bundler from 2.2.16 to 2.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.42.8...HEAD)
 
-- Bump bundler from 2.2.15 to 2.2.16 [#503](https://github.com/sider/devon_rex/pull/503)
+- Bump bundler from 2.2.15 to 2.2.17 [#503](https://github.com/sider/devon_rex/pull/503) [#519](https://github.com/sider/devon_rex/pull/519)
 - Bump npm from 7.8.0 to 7.11.1 [#501](https://github.com/sider/devon_rex/pull/501) [#505](https://github.com/sider/devon_rex/pull/505) [#514](https://github.com/sider/devon_rex/pull/514)
 - Bump debian from buster-20210329 to buster-20210408 [#495](https://github.com/sider/devon_rex/pull/495)
 - Bump python from 3.9.2-buster to 3.9.4-buster [#498](https://github.com/sider/devon_rex/pull/498)

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.7.1'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '2.2.16'
+gem 'bundler', '2.2.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.16)
+  bundler (= 2.2.17)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.16
+   2.2.17


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.17
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.17/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.16/2.2.17