### PR TITLE
Bump node from 14.16.0-buster to 14.16.1-buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Bump pip from 21.0.1 to 21.1.1 [#515](https://github.com/sider/devon_rex/pull/515) [#518](https://github.com/sider/devon_rex/pull/518)
 - Bump composer from 1.10.21 to 1.10.22 [#520](https://github.com/sider/devon_rex/pull/520)
 - Bump golang from 1.16.3-buster to 1.16.4-buster [#521](https://github.com/sider/devon_rex/pull/521)
+- Bump node from 14.16.0-buster to 14.16.1-buster [#524](https://github.com/sider/devon_rex/pull/524)
 - Install `file` command [#506](https://github.com/sider/devon_rex/pull/506)
 - Add `RUNNER_USER_BIN` environment variable [#508](https://github.com/sider/devon_rex/pull/508)
 

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /tmp/git-build && \
     make install DESTDIR=/opt/git
 
 
-FROM node:14.16.0-buster
+FROM node:14.16.1-buster
 
 ENV GLOBAL_RUBY_VERSION 2.7.3
 ENV LANG en_US.UTF-8

--- a/npm/Dockerfile.erb
+++ b/npm/Dockerfile.erb
@@ -1,6 +1,6 @@
 <%= ERB.new(File.read('base/Dockerfile.git.erb')).result %>
 
-FROM node:14.16.0-buster
+FROM node:14.16.1-buster
 
 <%= ERB.new(File.read('base/Dockerfile.env.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>


### PR DESCRIPTION
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#14.16.1