### PR TITLE
Bump bundler from 2.2.17 to 2.2.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.7.1'
 gem 'dotenv'
 gem 'rake'
 
-gem 'bundler', '2.2.17'
+gem 'bundler', '2.2.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.17)
+  bundler (= 2.2.18)
   dotenv
   rake
 
 BUNDLED WITH
-   2.2.17
+   2.2.18


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.18
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.18/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.17/2.2.18