### PR TITLE
Improve Composer installation

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
 # GLOBAL_RUBY_VERSION is set by .ruby-version
 LANGUAGE=en_US.UTF-8
 DEVON_REX_RUNNER_USER=analyzer_runner
-COMPOSER_VERSION=1.10.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Bump golang from 1.16.4-buster to 1.16.5-buster [#545](https://github.com/sider/devon_rex/pull/545)
 - Bump git from 2.31.1 to 2.32.0 [#547](https://github.com/sider/devon_rex/pull/547)
 - Bump gradle from 6.9 to 7.0.2 [#548](https://github.com/sider/devon_rex/pull/548)
+- Improve Composer installation [#549](https://github.com/sider/devon_rex/pull/549)
 
 ## 2.43.3
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -86,19 +86,22 @@ RUN bundler_version=$(grep --word-regexp 'bundler' /tmp/devon_rex_work/Gemfile |
 USER root
 
 # PHP configuration
-RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
-COPY php/sider.ini $PHP_INI_DIR/conf.d/sider.ini
+RUN mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+COPY php/sider.ini ${PHP_INI_DIR}/conf.d/sider.ini
 
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=1.10.22 && \
-    composer --version | grep 'Composer version 1.10.22 '
-
-ENV COMPOSER_HOME $RUNNER_USER_HOME/.composer
-ENV COMPOSER_VENDOR_BIN $COMPOSER_HOME/vendor/bin
-ENV PATH $COMPOSER_VENDOR_BIN:$PATH
+# Install Composer - https://getcomposer.org/download/
+ARG COMPOSER_VERSION=1.10.22
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version="${COMPOSER_VERSION}" && \
+    php -r "unlink('composer-setup.php');" && \
+    composer --version | grep "Composer version ${COMPOSER_VERSION} "
+ENV COMPOSER_HOME ${RUNNER_USER_HOME}/.composer
+ENV COMPOSER_VENDOR_BIN ${COMPOSER_HOME}/vendor/bin
+ENV PATH ${COMPOSER_VENDOR_BIN}:$PATH
 
 USER $RUNNER_USER
-RUN mkdir -p $COMPOSER_VENDOR_BIN
+RUN mkdir -p "${COMPOSER_VENDOR_BIN}"
 
 USER root
 RUN rm -rf /tmp/devon_rex_work
@@ -107,4 +110,4 @@ RUN rm -rf /tmp/devon_rex_work
 USER $RUNNER_USER
 
 
-CMD php -v && composer --version
+CMD ["php", "--version"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -86,7 +86,7 @@ RUN bundler_version=$(grep --word-regexp 'bundler' /tmp/devon_rex_work/Gemfile |
 USER root
 
 # PHP configuration
-RUN mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+RUN mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini"
 COPY php/sider.ini ${PHP_INI_DIR}/conf.d/sider.ini
 
 # Install Composer - https://getcomposer.org/download/

--- a/php/Dockerfile.erb
+++ b/php/Dockerfile.erb
@@ -8,7 +8,7 @@ FROM php:7.4.16-buster
 USER root
 
 # PHP configuration
-RUN mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+RUN mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini"
 COPY php/sider.ini ${PHP_INI_DIR}/conf.d/sider.ini
 
 # Install Composer - https://getcomposer.org/download/

--- a/php/Dockerfile.erb
+++ b/php/Dockerfile.erb
@@ -8,20 +8,23 @@ FROM php:7.4.16-buster
 USER root
 
 # PHP configuration
-RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
-COPY php/sider.ini $PHP_INI_DIR/conf.d/sider.ini
+RUN mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+COPY php/sider.ini ${PHP_INI_DIR}/conf.d/sider.ini
 
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=<%= ENV.fetch('COMPOSER_VERSION') %> && \
-    composer --version | grep 'Composer version <%= ENV.fetch('COMPOSER_VERSION') %> '
-
-ENV COMPOSER_HOME $RUNNER_USER_HOME/.composer
-ENV COMPOSER_VENDOR_BIN $COMPOSER_HOME/vendor/bin
-ENV PATH $COMPOSER_VENDOR_BIN:$PATH
+# Install Composer - https://getcomposer.org/download/
+ARG COMPOSER_VERSION=1.10.22
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version="${COMPOSER_VERSION}" && \
+    php -r "unlink('composer-setup.php');" && \
+    composer --version | grep "Composer version ${COMPOSER_VERSION} "
+ENV COMPOSER_HOME ${RUNNER_USER_HOME}/.composer
+ENV COMPOSER_VENDOR_BIN ${COMPOSER_HOME}/vendor/bin
+ENV PATH ${COMPOSER_VENDOR_BIN}:$PATH
 
 USER $RUNNER_USER
-RUN mkdir -p $COMPOSER_VENDOR_BIN
+RUN mkdir -p "${COMPOSER_VENDOR_BIN}"
 
 <%= ERB.new(File.read('base/Dockerfile.cleanup.erb')).result %>
 
-CMD php -v && composer --version
+CMD ["php", "--version"]


### PR DESCRIPTION
This change improves the Composer installation according to the official document:
https://getcomposer.org/download/

The new way is safer than the old way using `curl` because the old way may uses a malicious shell script.

Note: This change removes the version from the `.env` file.