### PR TITLE
Bump bundler from 2.2.20 to 2.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/devon_rex/compare/2.44.2...HEAD)
 
 - Bump gradle from 7.0.2 to 7.1 [#555](https://github.com/sider/devon_rex/pull/555)
+- Bump bundler from 2.2.20 to 2.2.21 [#558](https://github.com/sider/devon_rex/pull/558)
 
 ## 2.44.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.7.1'
-gem 'bundler', '2.2.20'
+gem 'bundler', '2.2.21'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.20)
+  bundler (= 2.2.21)
   erb
   rake
 
 BUNDLED WITH
-   2.2.20
+   2.2.21


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.21
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.21/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.20/2.2.21