### PR TITLE
Optimize Git installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Bump bundler from 2.2.20 to 2.2.21 [#558](https://github.com/sider/devon_rex/pull/558)
 - Bump debian from buster-20210511 to buster-20210621 [#557](https://github.com/sider/devon_rex/pull/557)
 - Bump npm from 7.17.0 to 7.19.0 [#559](https://github.com/sider/devon_rex/pull/559)
+- Optimize Git installation [#562](https://github.com/sider/devon_rex/pull/562)
 
 ## 2.44.2
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM debian:buster-20210621
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/base/Dockerfile.git.erb
+++ b/base/Dockerfile.git.erb
@@ -6,13 +6,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -22,8 +24,6 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install

--- a/base/Dockerfile.prepare.erb
+++ b/base/Dockerfile.prepare.erb
@@ -2,7 +2,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM mcr.microsoft.com/dotnet/sdk:3.1.410-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM golang:1.16.5-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM haskell:8.10.2-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM openjdk:15.0.2-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM node:14.16.1-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM php:7.4.16-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 FROM python:3.9.5-buster
@@ -51,7 +51,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -10,13 +10,15 @@ ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SO
 ARG GIT_SOURCE_SHA256_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
 ARG DEBIAN_FRONTEND=noninteractive
 
-# See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# See:
+# - https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+# - https://github.com/git/git/blob/v2.32.0/INSTALL
+# - https://github.com/git/git/blob/v2.32.0/Makefile
 RUN apt-get update -y && \
     apt-get install -qq -y --no-install-recommends \
       dh-autoreconf \
       libcurl4-gnutls-dev \
       libexpat1-dev \
-      gettext \
       libz-dev \
       libssl-dev \
       curl \
@@ -26,11 +28,9 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     curl -fsSL --compressed "${GIT_SOURCE_SHA256_URL}" | \
       grep "${GIT_SOURCE_TARBALL}" | \
       sha256sum --check --strict && \
-    mkdir -p /tmp/git-build && tar -xf "${GIT_SOURCE_TARBALL}" -C /tmp/git-build --strip-components=1
-RUN cd /tmp/git-build && \
-    make configure && \
-    ./configure && \
-    make install DESTDIR=/opt/git
+    tar -xf "${GIT_SOURCE_TARBALL}" && \
+    cd "git-${GIT_VERSION}" && \
+    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
 
 
 # NOTE: Make sure the version of glibc is higher than the system that compiles Ruby.
@@ -52,7 +52,7 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /
+COPY --from=git-builder /opt/git /usr/local/
 RUN test "$(git --version)" = "git version 2.32.0"
 
 # Install Ruby


### PR DESCRIPTION
This change aims to reduce the Docker images by optimizing the `git` installation.

Effect of `docker image ls sider/devon_rex_base:dev`: 813MB -> 797MB

See also:
- https://github.com/git/git/blob/v2.32.0/INSTALL
- https://github.com/git/git/blob/v2.32.0/Makefile