### PR TITLE
Remove apt packages cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Bump debian from buster-20210511 to buster-20210621 [#557](https://github.com/sider/devon_rex/pull/557)
 - Bump npm from 7.17.0 to 7.19.0 [#559](https://github.com/sider/devon_rex/pull/559)
 - Optimize Git installation [#562](https://github.com/sider/devon_rex/pull/562)
+- Remove apt packages cache [#563](https://github.com/sider/devon_rex/pull/563)
 
 ## 2.44.2
 

--- a/base/bin/prepare
+++ b/base/bin/prepare
@@ -34,6 +34,7 @@ apt-get update -y
 apt-get install -qq -y --no-install-recommends ${required_packages[*]}
 apt-get -qyy autoremove
 apt-get -qyy clean
+rm -rf /var/lib/apt/lists/*
 
 # Configure locale
 sed -i -e "s/# ${LANGUAGE}/${LANGUAGE}/" /etc/locale.gen


### PR DESCRIPTION
This change aims to reduce the Docker images’ size by removing apt packages cache.
Thus, we can reduce the `sider/devon_rex_base` image size: 797MB -> 780MB.