### PR TITLE
Fix Git installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.0...HEAD)
 
+- Fix Git installation [#572](https://github.com/sider/devon_rex/pull/572)
+
 ## 2.45.0
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.44.2...2.45.0)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM debian:buster-20210621
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM debian:buster-20210621

--- a/base/Dockerfile.git.erb
+++ b/base/Dockerfile.git.erb
@@ -1,5 +1,6 @@
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -27,6 +28,5 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install

--- a/base/Dockerfile.git.erb
+++ b/base/Dockerfile.git.erb
@@ -26,4 +26,7 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install

--- a/base/Dockerfile.prepare.erb
+++ b/base/Dockerfile.prepare.erb
@@ -2,8 +2,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:<%= ENV.fetch('GLOBAL_RUBY_VERSION') %> /usr/local /usr/local/

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM mcr.microsoft.com/dotnet/sdk:3.1.410-buster

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM mcr.microsoft.com/dotnet/sdk:3.1.410-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM golang:1.16.5-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM golang:1.16.5-buster

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM openjdk:15.0.2-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM openjdk:15.0.2-buster

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM node:14.16.1-buster

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM node:14.16.1-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM php:7.4.16-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM php:7.4.16-buster

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 FROM python:3.9.5-buster

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 FROM python:3.9.5-buster
@@ -51,8 +54,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -30,7 +30,10 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
       sha256sum --check --strict && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
-    make prefix=/opt/git NO_TCLTK=1 NO_GETTEXT=1 install
+    make configure && \
+    ./configure --prefix=/opt/git --without-tcltk && \
+    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
+    make "-j${CPUS}" NO_GETTEXT=1 install
 
 
 # NOTE: Make sure the version of glibc is higher than the system that compiles Ruby.
@@ -52,8 +55,11 @@ COPY base/bin/prepare /tmp/devon_rex_work/
 RUN /tmp/devon_rex_work/prepare
 
 # Install Git and verify the specified version of Git is installed
-COPY --from=git-builder /opt/git /usr/local/
-RUN test "$(git --version)" = "git version 2.32.0"
+COPY --from=git-builder /opt/git /opt/git
+ENV PATH /opt/git/bin:${PATH}
+RUN test "$(git --version)" = "git version 2.32.0" && \
+    git clone --quiet --depth=1 https://github.com/sider/devon_rex.git && \
+    rm -rf devon_rex
 
 # Install Ruby
 COPY --from=ruby:2.7.3 /usr/local /usr/local/

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -4,6 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM debian:buster-20210621 AS git-builder
 
+ARG GIT_PREFIX=/opt/git
 ARG GIT_VERSION=2.32.0
 ARG GIT_SOURCE_TARBALL=git-${GIT_VERSION}.tar.xz
 ARG GIT_SOURCE_URL=https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SOURCE_TARBALL}
@@ -31,9 +32,8 @@ RUN curl -fsSLO --compressed "${GIT_SOURCE_URL}" && \
     tar -xf "${GIT_SOURCE_TARBALL}" && \
     cd "git-${GIT_VERSION}" && \
     make configure && \
-    ./configure --prefix=/opt/git --without-tcltk && \
-    CPUS=$(grep -c ^processor /proc/cpuinfo) && \
-    make "-j${CPUS}" NO_GETTEXT=1 install
+    ./configure --prefix="${GIT_PREFIX}" --without-tcltk && \
+    make "-j$(nproc)" NO_GETTEXT=1 install
 
 
 # NOTE: Make sure the version of glibc is higher than the system that compiles Ruby.


### PR DESCRIPTION
This change aims to fix a bug introduced by PR #562.

For example, git-clone(1) fails as below:

```console
$ git clone -q https://github.com/sider/devon_rex.git
git: 'remote-https' is not a git command. See 'git --help'.
```