### PR TITLE
Configure Dependabot for Node.js Docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
     ignore:
       - dependency-name: node
         # NOTE: Node 14 is the current LTS version. See <https://github.com/nodejs/Release#readme>.
-        versions: ["> 14"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: docker
     directory: "/php"
     schedule:


### PR DESCRIPTION
The latest version of Node.js is [14.17.2](https://github.com/nodejs/node/blob/v14.17.2/doc/changelogs/CHANGELOG_V14.md), but Dependabot does not update it.

https://github.com/sider/devon_rex/blob/b76d1fa5888b023965cd3979da7a5c95b9907fa6/npm/Dockerfile#L39

This change aims to fix the problem.

See also:
- https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore