### PR TITLE
Bump bundler from 2.2.21 to 2.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.2...HEAD)
 
+- Bump bundler from 2.2.21 to 2.2.22 [#582](https://github.com/sider/devon_rex/pull/582)
+
 ## 2.45.2
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.1...2.45.2)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben', github: 'ybiquitous/aufgaben', tag: '0.7.1'
-gem 'bundler', '2.2.21'
+gem 'bundler', '2.2.22'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben!
-  bundler (= 2.2.21)
+  bundler (= 2.2.22)
   erb
   rake
 
 BUNDLED WITH
-   2.2.21
+   2.2.22


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.22
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.22/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.21/2.2.22