### PR TITLE
Preferred CMD form

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -95,4 +95,4 @@ RUN rm -rf /tmp/devon_rex_work
 USER $RUNNER_USER
 
 
-CMD ruby -v && gem -v && bundle -v
+CMD ["ruby", "--version"]

--- a/base/Dockerfile.erb
+++ b/base/Dockerfile.erb
@@ -6,4 +6,4 @@ FROM debian:buster-20210621
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.cleanup.erb')).result %>
 
-CMD ruby -v && gem -v && bundle -v
+CMD ["ruby", "--version"]

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -96,4 +96,4 @@ RUN rm -rf /tmp/devon_rex_work
 USER $RUNNER_USER
 
 
-CMD swift -version
+CMD ["swift", "-version"]

--- a/swift/Dockerfile.erb
+++ b/swift/Dockerfile.erb
@@ -7,4 +7,4 @@ FROM swift:5.3-focal
 <%= ERB.new(File.read('base/Dockerfile.prepare.erb')).result %>
 <%= ERB.new(File.read('base/Dockerfile.cleanup.erb')).result %>
 
-CMD swift -version
+CMD ["swift", "-version"]


### PR DESCRIPTION
`CMD ["executable","param1","param2"]` form is preferred officially.
See <https://docs.docker.com/engine/reference/builder/#cmd>