### PR TITLE
Bump bundler from 2.2.22 to 2.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.2...HEAD)
 
-- Bump bundler from 2.2.21 to 2.2.22 [#582](https://github.com/sider/devon_rex/pull/582)
+- Bump bundler from 2.2.21 to 2.2.23 [#582](https://github.com/sider/devon_rex/pull/582) [#586](https://github.com/sider/devon_rex/pull/586)
 - Bump Ruby from 2.7.3 to 2.7.4 [#584](https://github.com/sider/devon_rex/pull/584)
 
 ## 2.45.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben'
-gem 'bundler', '2.2.22'
+gem 'bundler', '2.2.23'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben
-  bundler (= 2.2.22)
+  bundler (= 2.2.23)
   erb
   rake
 
 BUNDLED WITH
-   2.2.22
+   2.2.23


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.23
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.23/bundler/CHANGELOG.md
- https://github.com/rubygems/rubygems/compare/bundler-v2.2.22...bundler-v2.2.23
- https://my.diffend.io/gems/bundler/2.2.22/2.2.23