### PR TITLE
Bump bundler from 2.2.23 to 2.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.3...HEAD)
 
+- Bump bundler from 2.2.23 to 2.2.24 [#590](https://github.com/sider/devon_rex/pull/590)
+
 ## 2.45.3
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.2...2.45.3)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben'
-gem 'bundler', '2.2.23'
+gem 'bundler', '2.2.24'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben
-  bundler (= 2.2.23)
+  bundler (= 2.2.24)
   erb
   rake
 
 BUNDLED WITH
-   2.2.23
+   2.2.24


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.24
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.24/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.23/2.2.24