### PR TITLE
Fix the broken link on ChangeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.45.5
 
-[Full diff](https://github.com/sider/devon_rex/compare/2.45.4...HEAD)
+[Full diff](https://github.com/sider/devon_rex/compare/2.45.4...2.45.5)
 
 ## 2.45.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-[Full diff](/2.45.5...HEAD)
+[Full diff](https://github.com/sider/devon_rex/compare/2.45.5...HEAD)
+
+- Fix the broken link on ChangeLog [#605](https://github.com/sider/devon_rex/pull/605)
 
 ## 2.45.5
 


### PR DESCRIPTION
I fixed the broken link on `ChangeLog`.