### PR TITLE
Use Ruby buster Docker image and bump bundler from 2.2.24 to 2.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.8...HEAD)
 
+- Change Ruby Docker image to Ruby buster [#623](https://github.com/sider/devon_rex/pull/623)
+- Bump bundler from 2.2.24 to 2.2.26 [#623](https://github.com/sider/devon_rex/pull/623)
+
 ## 2.45.8
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.7...2.45.8)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben'
-gem 'bundler', '2.2.24'
+gem 'bundler', '2.2.26'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben
-  bundler (= 2.2.24)
+  bundler (= 2.2.26)
   erb
   rake
 
 BUNDLED WITH
-   2.2.24
+   2.2.26

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/base/Dockerfile.prepare.erb
+++ b/base/Dockerfile.prepare.erb
@@ -9,7 +9,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:<%= ENV.fetch('GLOBAL_RUBY_VERSION') %> /usr/local /usr/local/
+COPY --from=ruby:<%= ENV.fetch('GLOBAL_RUBY_VERSION') %>-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -61,7 +61,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -62,7 +62,7 @@ RUN test "$(git --version)" = "git version 2.32.0" && \
     rm -rf devon_rex
 
 # Install Ruby
-COPY --from=ruby:2.7.4 /usr/local /usr/local/
+COPY --from=ruby:2.7.4-buster /usr/local /usr/local/
 
 # Change owner to let $RUNNER_USER add certificate files
 # WARNING: This must be done after copying ruby:2.7.2


### PR DESCRIPTION
## User Ruby buster Docker image

`devon_rex` uses `Debian buster`, so using the `ruby-*-buster` image is better

https://github.com/sider/devon_rex/blob/b439605164ac091fb2d80c7848ee4598efeb3aaf/base/Dockerfile#L39

> Some of these tags may have names like bullseye or buster in them. These are the suite code names for releases of Debian and indicate which release the image is based on. 

- Document: https://hub.docker.com/_/ruby

## Bump bundler

- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.26
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.26/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.24/2.2.26