### PR TITLE
Bump bundler from 2.2.24 to 2.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.8...HEAD)
 
+- Bump bundler from 2.2.24 to 2.2.26 [#624](https://github.com/sider/devon_rex/pull/624)
+
 ## 2.45.8
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.7...2.45.8)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben'
-gem 'bundler', '2.2.24'
+gem 'bundler', '2.2.26'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben
-  bundler (= 2.2.24)
+  bundler (= 2.2.26)
   erb
   rake
 
 BUNDLED WITH
-   2.2.24
+   2.2.26


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.26
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.26/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.24/2.2.26