### PR TITLE
Add Goodcheck rule for Java version

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -9,6 +9,20 @@ rules:
       Update CHANGELOG.md when you change a based Docker image.
     justification:
       - When CHANGELOG.md is updated already.
+  - id: sider.devon_rex.check_java_version
+    pattern:
+      regexp: |-
+        FROM openjdk:16.(.*).(.*)-buster
+    glob: "**/Dockerfile.erb"
+    message: |
+      **DO NOT MERGE!**
+
+      ktlint does not support Java 16.
+
+      * See details on [devon_rex/issues#564](https://github.com/sider/devon_rex/issues/564)
+    justification:
+      - When ktlint supports Java 16.
+
 
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml


### PR DESCRIPTION
`ktlint` doesn't support Java 16, so we shouldn't merge [Bump openjdk from 15.0.2-buster to 16.0.2-buster in /java](https://github.com/sider/devon_rex/pull/636).

- https://github.com/pinterest/ktlint/issues/1195

* Related: https://github.com/sider/devon_rex/pull/601#issuecomment-900914096

However, sometimes we forgot the history or issue about it, so I add a `Goodcheck` rule to prevent miss-merging.

![Screen Shot 2021-09-08 at 16 26 37](https://user-images.githubusercontent.com/42969906/132465288-a3a644a8-d079-406e-b8c9-c3ea03c8e595.jpg)

- Related: https://github.com/sider/devon_rex/issues/564