### PR TITLE
Bump bundler from 2.2.26 to 2.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.10...HEAD)
 
+- Bump bundler from 2.2.26 to 2.2.27 [#653](https://github.com/sider/devon_rex/pull/653)
+
 ## 2.45.10
 
 [Full diff](https://github.com/sider/devon_rex/compare/2.45.9...2.45.10)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aufgaben'
-gem 'bundler', '2.2.26'
+gem 'bundler', '2.2.27'
 gem 'erb'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ PLATFORMS
 
 DEPENDENCIES
   aufgaben
-  bundler (= 2.2.26)
+  bundler (= 2.2.27)
   erb
   rake
 
 BUNDLED WITH
-   2.2.26
+   2.2.27


### PR DESCRIPTION
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.27
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.27/bundler/CHANGELOG.md
- https://my.diffend.io/gems/bundler/2.2.26/2.2.27