### PR TITLE
Add a Goodcheck rule for npm

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -22,6 +22,15 @@ rules:
       * See details on [devon_rex/issues#564](https://github.com/sider/devon_rex/issues/564)
     justification:
       - When ktlint supports Java 16.
+  - id: sider.devon_rex.update_changelog_on_npm
+    pattern:
+      regexp: |-
+        "npm": "(.*)"
+    glob: "npm/package.json"
+    message: |
+      Update CHANGELOG.md when you change the npm version.
+    justification:
+      - When CHANGELOG.md is updated already.
 
 
 import:


### PR DESCRIPTION
There is a `Goodcheck` rule when the version is updated in the `Dockerfile` file.

https://github.com/sider/devon_rex/blob/a0f0bc4b7a90182205030e50d0ba1dea11f9b4d2/goodcheck.yml#L2-L11

So, when the version is updated in the `Dockerfile` file, we got the error in the `Sideci` on the PR https://github.com/sider/devon_rex/pull/654 like the below.

![Screen Shot 2021-09-14 at 11 27 58](https://user-images.githubusercontent.com/42969906/133184816-14e84174-43ea-4fef-ba7c-48751763e0fa.jpg)

However, there is no rule about the `npm` version that we should update the changelog together, so I just added a `Goodcheck` rule for it.

- PR of npm: https://github.com/sider/devon_rex/pull/654/files